### PR TITLE
Optimize create_bug_list() and modified_bugs()

### DIFF
--- a/ubuntu_server_triage.py
+++ b/ubuntu_server_triage.py
@@ -144,13 +144,13 @@ def modified_bugs(start_date, end_date, lpname, bugsubscriber):
             )}
 
     bugs_in_range = {
-        task for link, task in bugs_since_start.iteritems()
+        link: task for link, task in bugs_since_start.items()
         if link not in bugs_since_end
     }
 
     bugs = {
-        (bug.title, bug.status, (bug in already_sub_since_start))
-        for bug in bugs_in_range
+        (task.title, task.status, (link in already_sub_since_start))
+        for link, task in bugs_in_range.items()
     }
 
     return bugs


### PR DESCRIPTION
create_bug_list() was taking on the order of five minutes to return a
week's batch of bugs from a month ago, and was not completing (more than
twenty minutes) on a request for a week's batch of bugs from the start
of the year.

I identified two inefficiencies:

1. In addition to making queries for the bugs themselves,
modified_bugs() was additionally spending time making queries retrieving
data for each of the bugs returned. In the case of a small date range a
long time ago, most of these results were thrown away by
create_bug_list() immediately.

2. Finding a difference between lists using a list comprehension
directly takes O(n^2) time, since the "in" operator uses a linear
search.

I fix these by:

1. Pushing the date range through to modified_bugs() so that it can work
out the set difference itself. Then it need only retrieve additional bug
data for the bugs that actually fall within the range. This involves
changing modified_bugs()'s signature and the call to it from
create_bug_list().

2. Using a hash-based set difference calculation by using dictionaries
instead of lists. Since we no longer retrieve the bug data, we cannot
use the title/status/subscription status to eliminate dupes. Instead we
use the tasks' self_link attributes, which are guaranteed canonical
identifiers.

Now my (local) instrumentation shows that virtually all inside
modified_bugs() is spent inside the three essential Launchpad queries
only.

This makes backdated queries practical. The total query time for a week
of bugs from December 2015 now takes 2-3 minutes, which is mostly in the
two modified_since Launchpad queries.