### PR TITLE
Expiration on Triaging day(s)

### DIFF
--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -378,7 +378,8 @@ def main(date_range=None, debug=False, open_browser=None,
 
     if expiration['show_expiration']:
         logging.info('---')
-        logging.info('%s subscribed Bugs tagged %s older than %s days',
+        logging.info('%s subscribed Bugs tagged %s not touched in %s days '
+                     'relative to the specified triage period',
                      lpname,
                      expiration['tag_next'], expiration['expire_next'])
         expire_start = (datetime.strptime(date_range['start'], '%Y-%m-%d')
@@ -395,7 +396,8 @@ def main(date_range=None, debug=False, open_browser=None,
                    blacklist=blacklist)
 
         logging.info('---')
-        logging.info('%s subscribed Bugs older than than %s days',
+        logging.info('%s subscribed Bugs not touched in %s days '
+                     'relative to the specified triage period',
                      lpname, expiration['expire'])
         expire_start = (datetime.strptime(date_range['start'], '%Y-%m-%d')
                         - timedelta(days=expiration['expire']))

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -365,6 +365,12 @@ def main(date_range=None, debug=False, open_browser=None,
         )
     else:
         activitysubscribers = []
+
+    logging.info('---')
+    logging.info('%s (%s) subscribed Bugs last touched in the specified '
+                 'triage period %s - %s ',
+                 lpname, "direct" if bugsubscriber else "structural",
+                 date_range['start'], date_range['end'])
     bugs = create_bug_list(
         date_range['start'], date_range['end'],
         lpname, bugsubscriber, nodatefilter, activitysubscribers

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -454,7 +454,7 @@ def launch():
                         default=True,
                         action='store_false',
                         dest='show_expiration',
-                        help='Report about expiration of triaged bugs')
+                        help='Do not report about expiration of bugs')
     parser.add_argument('--expire-next',
                         default=60,
                         dest='expire_next',

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -353,9 +353,8 @@ def main(date_range=None, debug=False, open_browser=None,
     """
     blacklist = blacklist or None
 
-    log_level = logging.DEBUG if debug else logging.INFO
     logging.basicConfig(stream=sys.stdout, format='%(message)s',
-                        level=log_level)
+                        level=logging.DEBUG if debug else logging.INFO)
 
     launchpad = connect_launchpad()
     logging.info('Ubuntu Server Bug List')

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -26,7 +26,6 @@ PACKAGE_BLACKLIST = {
     'maas',
 }
 TEAMLPNAME = "ubuntu-server"
-OLDESTTRIAGE = "2012-01-01"
 
 
 class Task(object):
@@ -382,10 +381,14 @@ def main(date_range=None, debug=False, open_browser=None,
         logging.info('%s subscribed Bugs tagged %s older than %s days',
                      lpname,
                      expiration['tag_next'], expiration['expire_next'])
-        expire = (datetime.now() - timedelta(days=expiration['expire_next']))
-        expire = expire.strftime('%Y-%m-%d')
-        bugs = create_bug_list(OLDESTTRIAGE,
-                               expire,
+        expire_start = (datetime.strptime(date_range['start'], '%Y-%m-%d')
+                        - timedelta(days=expiration['expire_next']))
+        expire_end = (datetime.strptime(date_range['end'], '%Y-%m-%d')
+                      - timedelta(days=expiration['expire_next']))
+        expire_start = expire_start.strftime('%Y-%m-%d')
+        expire_end = expire_end.strftime('%Y-%m-%d')
+        bugs = create_bug_list(expire_start,
+                               expire_end,
                                lpname, TEAMLPNAME, None, None,
                                tag=["server-next", "-bot-stop-nagging"])
         print_bugs(bugs, open_browser['exp'], shortlinks,
@@ -394,10 +397,14 @@ def main(date_range=None, debug=False, open_browser=None,
         logging.info('---')
         logging.info('%s subscribed Bugs older than than %s days',
                      lpname, expiration['expire'])
-        expire = (datetime.now() - timedelta(days=expiration['expire']))
-        expire = expire.strftime('%Y-%m-%d')
-        bugs = create_bug_list(OLDESTTRIAGE,
-                               expire,
+        expire_start = (datetime.strptime(date_range['start'], '%Y-%m-%d')
+                        - timedelta(days=expiration['expire']))
+        expire_end = (datetime.strptime(date_range['end'], '%Y-%m-%d')
+                      - timedelta(days=expiration['expire']))
+        expire_start = expire_start.strftime('%Y-%m-%d')
+        expire_end = expire_end.strftime('%Y-%m-%d')
+        bugs = create_bug_list(expire_start,
+                               expire_end,
                                lpname, TEAMLPNAME, None, None,
                                tag="-bot-stop-nagging")
         print_bugs(bugs, open_browser['exp'], shortlinks,


### PR DESCRIPTION
After discussing with rbasak the current mode of "list all expired" bugs is bad in multiple ways.
- It is depressing for the current triager, who likely will not handle any of those
- We need to split this backlog among the server Team, but showing up every day hides what the daily triage duty is responsible for

After this change a Triager will only see those that he needs to take care of.

In many ways this is the same that we had initially with the un-triaged time that we had to cover.
Therefore we track the backlog in the same gdoc where we did already track the general triaging backlog.