### PR TITLE
Fix double listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ The easiest way to obtain the script and keep it updated is to use the snap:
 sudo snap install ustriage --classic
 ```
 
-If using the snap is not possible, you can instead obtain and run it by:
+If using the snap is not possible, you can instead obtain it from git and run it by:
 ```
-wget https://raw.githubusercontent.com/powersj/ubuntu-server-triage/master/ustriage/ustriage.py
-chmod +x ustriage.py 
 # Running with no arguments will get previous day's bugs
-./ustriage.py
+python -m ustriage
 ```
 
 ## Dates

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -132,4 +132,4 @@ class Task:
 
     def sort_key(self):
         """Sort method."""
-        return (not self.last_activity_ours, self.src)
+        return (not self.last_activity_ours, self.number, self.src)

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -110,6 +110,26 @@ class Task:
             ('[%s]' % self.src), self.short_title
         )
 
+    def compose_dup(self, shortlinks=True):
+        """Compose a printable line of reduced information for a dup."""
+        if shortlinks:
+            duplen = str(self.BUG_NUMBER_LENGTH + len(self.SHORTLINK_ROOT))
+        else:
+            duplen = str(self.BUG_NUMBER_LENGTH + len(self.LONG_URL_ROOT))
+        format_string = ('%-' + duplen + 's')
+        dupprefix = format_string % 'also:'
+
+        flags = '%s%s' % (
+            '*' if self.subscribed else '',
+            '+' if self.last_activity_ours else '',
+        )
+
+        return u'%s - %-16s %-16s - %s' % (
+            dupprefix,
+            ('%s(%s)' % (flags, self.status)),
+            ('[%s]' % self.src), self.short_title
+        )
+
     def sort_key(self):
         """Sort method."""
         return (not self.last_activity_ours, self.src)

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -92,7 +92,11 @@ def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None):
     opened = False
     reportedbugs = []
     for task in sorted_filtered_tasks:
-        print(task.compose_pretty(shortlinks=shortlinks))
+        if task.number in reportedbugs:
+            print(task.compose_dup(shortlinks=shortlinks))
+            continue
+        else:
+            print(task.compose_pretty(shortlinks=shortlinks))
 
         if open_in_browser:
             if opened:

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -90,6 +90,7 @@ def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None):
     logging.info('Found %s bugs', len(sorted_filtered_tasks))
 
     opened = False
+    reportedbugs = []
     for task in sorted_filtered_tasks:
         print(task.compose_pretty(shortlinks=shortlinks))
 
@@ -101,6 +102,7 @@ def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None):
                 webbrowser.open(task.url)
                 opened = True
                 time.sleep(5)
+        reportedbugs.append(task.number)
 
 
 def last_activity_ours(task, activitysubscribers):


### PR DESCRIPTION
I was always slightly annoyed when a bug was opened tabs for multiple times.
That just doesn't help - in cases where a bug has multiple tasks that all affect us we still want to link (in console) and open (in browser) it only once.

This weekend was an extreme case of that, so I decided to fix it.

Output before the fix:
```
Bugs for triage on 2018-10-12 to 2018-10-14 (inclusive)
Found 16 bugs
LP: #1781529 - +(In Progress)   [mecab]          - [MIR] mecab
LP: #1781529 - +(Fix Committed) [mecab-ipadic]   - [MIR] mecab
LP: #1792544 - (New)            [apache2]        - demotion of pcre3 (8.x) a.k.a pcre
LP: #1792544 - (Triaged)        [clamav]         - demotion of pcre3 (8.x) a.k.a pcre
LP: #1792544 - (Incomplete)     [exim4]          - demotion of pcre3 (8.x) a.k.a pcre
LP: #1792544 - (Incomplete)     [freeradius]     - demotion of pcre3 (8.x) a.k.a pcre
LP: #1792544 - (Triaged)        [haproxy]        - demotion of pcre3 (8.x) a.k.a pcre
LP: #1792544 - (Incomplete)     [libpam-mount]   - demotion of pcre3 (8.x) a.k.a pcre
LP: #1787405 - (Incomplete)     [libvirt]        - [19.04 FEAT] Guest-dedicated Crypto Adapters
LP: #1792544 - (Incomplete)     [nginx]          - demotion of pcre3 (8.x) a.k.a pcre
LP: #1792544 - (Incomplete)     [nmap]           - demotion of pcre3 (8.x) a.k.a pcre
LP: #1792544 - (Incomplete)     [postfix]        - demotion of pcre3 (8.x) a.k.a pcre
LP: #1787405 - (Incomplete)     [qemu]           - [19.04 FEAT] Guest-dedicated Crypto Adapters
LP: #1792544 - (Incomplete)     [quagga]         - demotion of pcre3 (8.x) a.k.a pcre
LP: #1775195 - (In Progress)    [sosreport]      - sosreport v3.6
LP: #1792544 - (Incomplete)     [sssd]           - demotion of pcre3 (8.x) a.k.a pcre
```

And along that if you run with -o 16 times opening a tab.

With the changes it would group tasks of the same bug and report them clearly as belonging together.
It would also only open the tab once.

```
Bugs for triage on 2018-10-12 to 2018-10-14 (inclusive)
Found 16 bugs
LP: #1781529 - +(In Progress)   [mecab]          - [MIR] mecab
also:        - +(Fix Committed) [mecab-ipadic]   - [MIR] mecab
LP: #1775195 - (In Progress)    [sosreport]      - sosreport v3.6
LP: #1787405 - (Incomplete)     [libvirt]        - [19.04 FEAT] Guest-dedicated Crypto Adapters
also:        - (Incomplete)     [qemu]           - [19.04 FEAT] Guest-dedicated Crypto Adapters
LP: #1792544 - (New)            [apache2]        - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Triaged)        [clamav]         - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Incomplete)     [exim4]          - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Incomplete)     [freeradius]     - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Triaged)        [haproxy]        - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Incomplete)     [libpam-mount]   - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Incomplete)     [nginx]          - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Incomplete)     [nmap]           - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Incomplete)     [postfix]        - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Incomplete)     [quagga]         - demotion of pcre3 (8.x) a.k.a pcre
also:        - (Incomplete)     [sssd]           - demotion of pcre3 (8.x) a.k.a pcre
```

That is more readable and only 4 highlighted links (or tab open calls).