### PR TITLE
Date process improvements

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,4 +28,5 @@ parts:
         source: https://github.com/powersj/ubuntu-server-triage
         source-type: git
         stage-packages:
+            - python3-dateutil
             - python3-launchpadlib

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -303,11 +303,17 @@ def main(date_range=None, debug=False, open_browser=None,
     pretty_end = inclusive_end.strftime('%Y-%m-%d (%A)')
     logging.info('\'*\': %s is directly subscribed', lpname)
     logging.info('\'+\': last bug activity is ours')
-    logging.info(
-        'Bugs for triage on %s to %s (inclusive)',
-        pretty_start,
-        pretty_end
-    )
+    if inclusive_start == inclusive_end:
+        logging.info(
+            'Bugs last updated on %s',
+            pretty_start,
+        )
+    else:
+        logging.info(
+            'Bugs last updated between %s and %s inclusive',
+            pretty_start,
+            pretty_end
+        )
 
 
     bugs = create_bug_list(

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -81,18 +81,12 @@ def connect_launchpad():
                                 credential_store=credential_store)
 
 
-def parse_dates(start, end=None, nodatefilter=False):
+def parse_dates(start, end=None):
     """Validate dates are setup correctly."""
     # if start date is not set we search all bugs of a LP user/team
     if not start:
-        if nodatefilter:
-            logging.info('Searching all bugs, no date filter')
-            return datetime.min, datetime.now()
-
         logging.info('No date set, auto-search yesterday/weekend for the '
                      'most common triage.')
-        logging.info('Please specify -a if you really '
-                     'want to search without any date filter')
         yesterday = datetime.now().date() - timedelta(days=1)
         if yesterday.weekday() != 6:
             start = yesterday.strftime('%Y-%m-%d')
@@ -305,9 +299,8 @@ def print_expired_backlog_bugs(lpname, expiration, date_range, open_browser,
 
 
 def main(date_range=None, debug=False, open_browser=None,
-         lpname=TEAMLPNAME, bugsubscriber=False, nodatefilter=False,
-         shortlinks=True, activitysubscribernames=None, expiration=None,
-         blacklist=None):
+         lpname=TEAMLPNAME, bugsubscriber=False, shortlinks=True,
+         activitysubscribernames=None, expiration=None, blacklist=None):
     """Connect to Launchpad, get range of bugs, print 'em."""
     launchpad = connect_launchpad()
     logging.basicConfig(stream=sys.stdout, format='%(message)s',
@@ -324,8 +317,7 @@ def main(date_range=None, debug=False, open_browser=None,
         activitysubscribers = []
 
     date_range['start'], date_range['end'] = parse_dates(date_range['start'],
-                                                         date_range['end'],
-                                                         nodatefilter)
+                                                         date_range['end'])
 
     logging.info('---')
     # Need to display date range as inclusive
@@ -382,8 +374,6 @@ def launch():
     parser.add_argument('-O', '--open-expire', action='store_true',
                         dest='openexp',
                         help='open expiring bugs in web browser')
-    parser.add_argument('-a', '--nodatefilter', action='store_true',
-                        help='show all (no date restriction)')
     parser.add_argument('-n', '--lpname', default=TEAMLPNAME,
                         help='specify the launchpad name to search for')
     parser.add_argument('-b', '--bugsubscriber', action='store_true',
@@ -432,7 +422,7 @@ def launch():
                   'end': args.end_date}
 
     main(date_range, args.debug, open_browser,
-         args.lpname, args.bugsubscriber, args.nodatefilter, not args.fullurls,
+         args.lpname, args.bugsubscriber, not args.fullurls,
          args.activitysubscribers, expiration,
          blacklist=None if args.no_blacklist else PACKAGE_BLACKLIST)
 

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -81,7 +81,7 @@ def connect_launchpad():
                                 credential_store=credential_store)
 
 
-def check_dates(start, end=None, nodatefilter=False):
+def parse_dates(start, end=None, nodatefilter=False):
     """Validate dates are setup correctly."""
     # if start date is not set we search all bugs of a LP user/team
     if not start:
@@ -323,7 +323,7 @@ def main(date_range=None, debug=False, open_browser=None,
     else:
         activitysubscribers = []
 
-    date_range['start'], date_range['end'] = check_dates(date_range['start'],
+    date_range['start'], date_range['end'] = parse_dates(date_range['start'],
                                                          date_range['end'],
                                                          nodatefilter)
 

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -293,13 +293,22 @@ def main(date_range=None, debug=False, open_browser=None,
                                                          nodatefilter)
 
     logging.info('---')
-    # Need to make date range inclusive
-    end = datetime.strptime(date_range['end'], '%Y-%m-%d') - timedelta(days=1)
-    end = end.strftime('%Y-%m-%d')
+    # Need to display date range as inclusive
+    inclusive_start = datetime.strptime(date_range['start'], '%Y-%m-%d')
+    inclusive_end = (
+        datetime.strptime(date_range['end'], '%Y-%m-%d') -
+        timedelta(days=1)
+    )
+    pretty_start = inclusive_start.strftime('%Y-%m-%d (%A)')
+    pretty_end = inclusive_end.strftime('%Y-%m-%d (%A)')
     logging.info('\'*\': %s is directly subscribed', lpname)
     logging.info('\'+\': last bug activity is ours')
-    logging.info('Bugs for triage on %s to %s (inclusive)',
-                 date_range['start'], end)
+    logging.info(
+        'Bugs for triage on %s to %s (inclusive)',
+        pretty_start,
+        pretty_end
+    )
+
 
     bugs = create_bug_list(
         date_range['start'], date_range['end'],

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -11,6 +11,7 @@ import argparse
 from datetime import date, datetime, timedelta
 import logging
 import os
+import re
 import sys
 import time
 import webbrowser
@@ -95,10 +96,22 @@ def parse_dates(start, end=None):
             start = (yesterday - timedelta(days=2)).strftime('%Y-%m-%d')
             end = yesterday.strftime('%Y-%m-%d')
 
-    # If end date is not set set it to start so we can
-    # properly show the inclusive list of dates.
-    if not end:
-        end = start
+    if re.fullmatch(r'\d{4}-\d{2}-\d{2}', start):
+        # If end date is not set set it to start so we can
+        # properly show the inclusive list of dates.
+        if not end:
+            end = start
+
+    elif start and not end:
+        try:
+            start_date, end_date = auto_date_range(start)
+            start = start_date.strftime('%Y-%m-%d')
+            end = end_date.strftime('%Y-%m-%d')
+        except ValueError as e:
+            raise ValueError("Cannot parse date: %s" % start) from e
+
+    else:
+        raise ValueError("Cannot parse date range: %s %s" % (start, end))
 
     # Always add one to end date to make the dates inclusive
     end = datetime.strptime(end, '%Y-%m-%d') + timedelta(days=1)

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -70,6 +70,39 @@ def auto_date_range(keyword, today=None):
         return start, end
 
 
+def reverse_auto_date_range(start, end):
+    """Given a date range, return the "triage day" if it fits the process
+
+    This is the inverse of auto_date_range(). If the range matches a known
+    range the fits the process, describe the range as a string such as "Monday
+    triage". If no match, return None.
+
+    :param datetime.date start: the start of the range (inclusive)
+    :param datetime.date end: the end of the range (inclusive)
+    :returns: string describing the triage, or None
+    :rtype: str or None
+    """
+    if start > end:
+        return None  # process not specified
+    if (end - start).days > 2:
+        return None  # not a day or weekend triage range: process not specified
+
+    start_weekday = start.weekday()
+    end_weekday = end.weekday()
+
+    if start_weekday == 4 and end_weekday == 6:
+        return "Monday triage"
+    elif start == end:
+        if start_weekday in [5, 6]:
+            return None  # weekend: process not specified
+        else:
+            # must be regular day triage
+            day = ['Tuesday', 'Wednesday', 'Thursday', 'Friday'][start_weekday]
+            return "%s triage" % day
+    else:
+        return None
+
+
 def connect_launchpad():
     """Use the launchpad module connect to launchpad.
 

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -388,6 +388,9 @@ def main(date_range=None, debug=False, open_browser=None,
             pretty_end
         )
 
+    triage_day_name = reverse_auto_date_range(inclusive_start, inclusive_end)
+    if triage_day_name:
+        logging.info("Date range identified as: \"%s\"", triage_day_name)
 
     bugs = create_bug_list(
         date_range['start'], date_range['end'],

--- a/ustriage/ustriage_test.py
+++ b/ustriage/ustriage_test.py
@@ -28,3 +28,17 @@ def test_auto_date_range_weekend(today, keyword):
     today = parse_test_date(today)
     with pytest.raises(ValueError):
         target.auto_date_range(keyword, today=today)
+
+
+@pytest.mark.parametrize('start,end,expected', [
+    ('2019-05-10', '2019-05-12', 'Monday triage'),
+    ('2019-05-13', '2019-05-13', 'Tuesday triage'),
+    ('2019-05-06', '2019-05-06', 'Tuesday triage'),
+    ('2019-05-07', '2019-05-07', 'Wednesday triage'),
+    ('2019-05-06', '2019-05-07', None),  # two days apart, not Fri-Sun
+    ('2019-05-07', '2019-05-06', None),  # reverse range definition
+    ('2019-05-06', '2019-05-09', None),  # more than two days apart
+    ('2019-05-18', '2019-05-18', None),  # Saturday
+])
+def test_reverse_auto_date_range(start, end, expected):
+    assert target.reverse_auto_date_range(parse_test_date(start), parse_test_date(end)) == expected

--- a/ustriage/ustriage_test.py
+++ b/ustriage/ustriage_test.py
@@ -1,0 +1,30 @@
+import datetime
+
+import pytest
+
+import ustriage.ustriage as target
+
+
+def parse_test_date(date_string):
+    return datetime.datetime.strptime(date_string, '%Y-%m-%d').date()
+
+
+@pytest.mark.parametrize('today,keyword,start,end', [
+    ('2019-05-14', 'mon', '2019-05-10', '2019-05-12'),
+    ('2019-05-14', 'tue', '2019-05-13', '2019-05-13'),
+    ('2019-05-13', 'tue', '2019-05-06', '2019-05-06'),
+    ('2019-05-14', 'wed', '2019-05-07', '2019-05-07'),
+])
+def test_auto_date_range(today, keyword, start, end):
+    today = parse_test_date(today)
+    assert target.auto_date_range(keyword, today=today) == (parse_test_date(start), parse_test_date(end))
+
+
+@pytest.mark.parametrize('today,keyword', [
+    ('2019-05-14', 'sun'),
+    ('2019-05-14', 'sat'),
+])
+def test_auto_date_range_weekend(today, keyword):
+    today = parse_test_date(today)
+    with pytest.raises(ValueError):
+        target.auto_date_range(keyword, today=today)


### PR DESCRIPTION
Add the following features:
 1. A single positional argument that looks like a day of the week is taken to be the triage process action for that day, and automatically resolves to the correct date range. The date range is still printed for visual confirmation.
 2. Add day of week display to the date range in use when it is printed, for easy visual confirmation.
 3. If the date range printed corresponds to a triage process for some particular day, print that day, for easy visual confirmation.

Drop `-a`/`--nodatefilter` which was previously broken and non-functional anyway.

Functional behaviour changes are additions only and should be fully backwards compatible with previous use. Extra information is output to the terminal (day of week and triage day if matched).

Notes:
 * Adds some parameterized pytest tests (100% coverage for new functions), but doesn't add this to CI. Please advise on what to do here.
 * New dependency on dateutil (added to `snapcraft.yaml` for snap builds; untested).