### PR TITLE
Include results for stable-only tasks

### DIFF
--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -80,7 +80,7 @@ class Task:
         """Bug summary."""
         # This could be self.obj.bug.title but using self.title is
         # significantly faster
-        return ' '.join(self.title.split(' ')[5:]).replace('"', '')
+        return ' '.join(self.title.split(' ')[6:]).replace('"', '')
 
     def compose_pretty(self, shortlinks=True):
         """Compose a printable line of relevant information."""

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -42,7 +42,7 @@ DISTRIBUTION_RESOURCE_TYPE_LINK = (
 
 
 def searchTasks_in_all_active_series(distro, *args, **kwargs):  # noqa: E501 pylint: disable=invalid-name
-    """Unionize searchTasks() for all active series of a distribution
+    """Unionize searchTasks() for all active series of a distribution.
 
     A searchTasks() Launchpad call against a Launchpad distribution will not
     return series tasks if the development task is marked Fix Released (LP:


### PR DESCRIPTION
Due to LP: #314432, we have been failing to list bugs that only have
tasks for stable series (ie. where the development task has been marked
"Fix Released").

This implements the required workaround, which is to specifically
iterate through all relevant series.

A tweak to the bug title display hack is required, since now that all
our bug tasks are tied to specific series, bug title strings include the
series name.

The status field in the output will now be for an arbitrary series
instead of the development series. We could later implement an algorithm
to collapse the status field in a better way after we define how it
should be done, but for now, this is better than missing stable-only
tasks.

The script is now expected to run yet slower because we must make one
query for each series every time we previously made only one. However,
again this is better than missing stable-only tasks. Optimisations are
possible and we can work on them in the future if necessary.